### PR TITLE
Upgrade to gulp-sass@2.0.4 for Node v4 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "gulp-help": "^1.6.1",
     "gulp-imagemin": "^2.3.0",
     "gulp-minify-css": "^1.0.0",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.0.4",
     "gulp-uglify": "^1.2.0",
     "gulp-uncss": "^1.0.1",
     "gulp-util": "^3.0.4",


### PR DESCRIPTION
Hi,

Just setting up before DrupalCon Barcelona, `brew install node` is installing the newly launched [node v4.1.0](https://nodejs.org/en/blog/release/v4.1.0/). Attempting to run `gulp bs` leaves me with the issue raised on gulp-sass's repo -> https://github.com/dlmanning/gulp-sass/issues/340

After installing gulp-sass@2.0.4, the local server seems to be running as usual. The ghooks pre-push task did fail the tests, however. I'm not sure if that is intended or not, so disabled the hook locally so I could make this PR.